### PR TITLE
Edit search component

### DIFF
--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -6,11 +6,11 @@ import Icon from '../../icon.js';
 import styles from './search.scss';
 
 export const Search = ({
-  onChange,
+  onSearch,
   placeholder,
   className,
 }) => {
-  const handleChange = (event) => onChange(event.target.value);
+  const handleChange = (event) => onSearch(event.target.value);
 
   return (
     <div className={styles.search}>
@@ -26,7 +26,7 @@ export const Search = ({
 };
 
 Search.propTypes = {
-  onChange: func.isRequired,
+  onSearch: func.isRequired,
   placeholder: PropTypes.string.isRequired,
   className: PropTypes.string,
 };

--- a/src/components/search/search.js
+++ b/src/components/search/search.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes, { func } from 'prop-types';
 import classNames from 'classnames';
 
@@ -6,32 +6,27 @@ import Icon from '../../icon.js';
 import styles from './search.scss';
 
 export const Search = ({
-  onSearch,
+  onChange,
   placeholder,
   className,
 }) => {
-  const [inputValue, setInputValue] = useState('');
-
-  const handleSearch = () => onSearch(inputValue);
-  const handleChange = (event) => setInputValue(event.target.value);
+  const handleChange = (event) => onChange(event.target.value);
 
   return (
-    <div className={classNames(styles.search, className)}>
+    <div className={styles.search}>
       <input
         type="text"
-        className={styles.searchInput}
+        className={classNames(styles.searchInput, className)}
         onChange={handleChange}
         placeholder={placeholder}
       />
-      <div onClick={handleSearch} className={styles.searchButton}>
-        <Icon icon="Search" size={32} viewBox="0 0 50 50" />
-      </div>
+      <Icon className={styles.searchIcon} icon="Search" size={32} viewBox="0 0 50 50" />
     </div>
   );
 };
 
 Search.propTypes = {
-  onSearch: func.isRequired,
+  onChange: func.isRequired,
   placeholder: PropTypes.string.isRequired,
   className: PropTypes.string,
 };

--- a/src/components/search/search.scss
+++ b/src/components/search/search.scss
@@ -2,42 +2,23 @@
 
 .search {
   position: relative;
-  display: flex;
+  display: inline-block;
 
   &Input{
     @include input;
-    width: 164px;
-    padding: 5px;
+    position: relative;
+    padding: 5px 5px 5px 32px;
     transition: all .1s;
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
 
     &:focus {
       outline: none;
       box-shadow: 0 0 10px map-get($colors, textAccentN1-color);
-      & + .searchButton {
-        box-shadow: 0 0 10px map-get($colors, textAccentN1-color);
-      }
     }
   }
 
-  &Button {
-    cursor: pointer;
-    width: 36px;
-    height: 36px;
-    position: relative;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    border: 1px solid map-get($colors, textAccentN1-color);
-    border-left: none;
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-
-    & > svg {
-      position: absolute;
-      top: 7px;
-      right: -5px;
-    }
+  &Icon {
+    position: absolute;
+    left: 7px;
+    top: 7px;
   }
 }

--- a/src/features/counter/counter.js
+++ b/src/features/counter/counter.js
@@ -36,7 +36,7 @@ export const Counter = () => {
       <Button type="button" onClick={handleShowModal} variant="success">Show modal</Button>
       <div className="m-3">
         <Search
-          onChange={handleSearch}
+          onSearch={handleSearch}
           placeholder="Search something"
         />
       </div>

--- a/src/features/counter/counter.js
+++ b/src/features/counter/counter.js
@@ -36,7 +36,7 @@ export const Counter = () => {
       <Button type="button" onClick={handleShowModal} variant="success">Show modal</Button>
       <div className="m-3">
         <Search
-          onSearch={handleSearch}
+          onChange={handleSearch}
           placeholder="Search something"
         />
       </div>


### PR DESCRIPTION
## Summary of [issue](https://github.com/ita-social-projects/what-front/issues/103)

Change Search Icon
Bring the Icon the beginning og the search input.
And make it invalid

## Summary of change

onSearch function is called on search value changed

### props
> Required: 
  - **onSearch**: ` func` - search input value changed, should accept parameter _inputValue_
  - **placeholder**: `string` - input placeholder
> Optional: 
  - **className**: `string` - additional class that you can apply search container Default: _''_

### Examples: 
```
<Search
   onSearch={handleSearch}
   placeholder="Search something"
 />
```

![image](https://user-images.githubusercontent.com/47292994/99417806-0296a580-2903-11eb-875e-b15524b5da6a.png)
![image](https://user-images.githubusercontent.com/47292994/99417846-0fb39480-2903-11eb-8689-f01d5bbd1c3b.png)
