### PR TITLE
Fix unassigned list

### DIFF
--- a/src/features/unassigned-list/unassigned-list.js
+++ b/src/features/unassigned-list/unassigned-list.js
@@ -82,7 +82,7 @@ export const UnAssignedList = () => {
       case 2:
         return <option value={1}>{roles[1]}</option>;
       case 3:
-        return roles.slice(0, 2).map((role) => (
+        return roles.slice(0, 3).map((role) => (
           <option key={role.id} value={roles.indexOf(role)}>
             {role.name}
           </option>

--- a/src/features/unassigned-list/unassigned-list.js
+++ b/src/features/unassigned-list/unassigned-list.js
@@ -1,16 +1,17 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { useActions } from '@/shared/index.js';
-import { newUserSelector, currentUserSelector, addMentor, createSecretary, addStudent } from '@/models/index.js';
 
-import { fetchUnAssignedUserList } from '@/models';
-import Icon from '../../icon.js';
-import { Search, Button, WithLoading } from '../../components/index.js';
+import { useActions } from '@/shared/index.js';
+import {
+  newUserSelector, currentUserSelector, addMentor,
+  createSecretary, addStudent, fetchUnAssignedUserList,
+} from '@/models/index.js';
+import { Search, Button, WithLoading } from '@/components';
+import Icon from '@/icon.js';
 
 import styles from './unassigned-list.scss';
 
 export const UnAssignedList = () => {
-  const roles = ['Choose role', 'student', 'mentor', 'secretary'];
   const { currentUser } = useSelector(currentUserSelector);
   const currentUserRole = currentUser.role;
   const { isLoaded, data, isLoading } = useSelector(newUserSelector);
@@ -23,6 +24,13 @@ export const UnAssignedList = () => {
 
   const [search, setSearch] = useState('');
   const [searchPersonValue, setSearchPersonValue] = useState([]);
+
+  const roles = [
+    { id: 0, name: 'Choose role' },
+    { id: 1, name: 'student' },
+    { id: 2, name: 'mentor' },
+    { id: 3, name: 'secretary' },
+  ];
 
   useEffect(() => {
     getUnAssignedUserList();
@@ -75,47 +83,47 @@ export const UnAssignedList = () => {
         return <option value={1}>{roles[1]}</option>;
       case 3:
         return roles.slice(0, 2).map((role) => (
-          <option value={roles.indexOf(role)}>
-            {role}
+          <option key={role.id} value={roles.indexOf(role)}>
+            {role.name}
           </option>
         ));
       case 4:
         return roles.map((role) => (
-          <option value={roles.indexOf(role)}>
-            {role}
+          <option key={role.id} value={roles.indexOf(role)}>
+            {role.name}
           </option>
         ));
       default: return {};
     }
   };
   const list = () => {
-    if (isLoading || isLoaded) {
-      if (searchPersonValue.length !== 0) {
-        return (searchPersonValue.map((user) => (
-          <div className={styles.card}>
-            <p><span className={styles.name}>{user.firstName} {user.lastName}</span><br /><span className="font-italic">{user.email}</span></p>
-            <div className={styles['add-role']}>
-              <select
-                className={styles.select}
-                onChange={(event) => { changeRole(user.id, event.target.value); }}
-              >
-                {options()}
-              </select>
-              <Button
-                className={styles.btn}
-                onClick={() => handleButtonClick(user.id)}
-                variant="warning"
-              >
-                <Icon icon="Plus" size={20} className="icon" />
-                Add role
-              </Button>
-            </div>
-          </div>
-        ))
-        );
-      }
+    const users = searchPersonValue.map((user) => (
+      <div className={styles.card} key={user.id}>
+        <p><span className={styles.name}>{user.firstName} {user.lastName}</span><br /><span className="font-italic">{user.email}</span></p>
+        <div className={styles['add-role']}>
+          <select
+            className={styles.select}
+            onChange={(event) => { changeRole(user.id, event.target.value); }}
+          >
+            {options()}
+          </select>
+          <Button
+            className={styles.btn}
+            onClick={() => handleButtonClick(user.id)}
+            variant="warning"
+          >
+            <Icon icon="Plus" size={20} className="icon" />
+            Add role
+          </Button>
+        </div>
+      </div>
+    ));
+
+    if (!searchPersonValue.length && search) {
+      return <span className={styles.massage}>Nobody was found</span>;
     }
-    return (<WithLoading isLoading={!isLoaded} className={styles.warning}><span className={styles.massage}>Nobody was found</span></WithLoading>);
+
+    return users;
   };
 
   return (
@@ -123,7 +131,9 @@ export const UnAssignedList = () => {
       <div className={styles.panel}>
         <Search onSearch={handleSearch} placeholder="Enter a person`s name" />
       </div>
-      <div className={styles.list}> {list()} </div>
+      <div className={styles.list}>
+        <WithLoading isLoading={!isLoaded} className="mt-3 d-block mx-auto">{list()}</WithLoading>
+      </div>
     </div>
   );
 };

--- a/src/features/unassigned-list/unassigned-list.scss
+++ b/src/features/unassigned-list/unassigned-list.scss
@@ -1,6 +1,6 @@
 @import '../../styles/main';
 
-.conteiner-list{
+.container-list{
     @include franklin-regular();
     width: 70%;
     height: 800px;
@@ -11,12 +11,9 @@
 }
 
 .list{
-    overflow-y: scroll;
-    overflow-x:hidden;
     margin: 20px;
-    overflow-y: scroll;
+    overflow-y: auto;
     overflow-x: hidden;
-    margin: 20px;
     height: 700px;
     border-bottom: solid 1px grey;
     border-top: solid 1px grey;
@@ -44,12 +41,6 @@
 .name {
   font-size: larger;
   font-weight: bolder;
-}
-
-.warning{
-    margin: auto;
-    position: relative;
-    left: 50%;
 }
 
 .btn{


### PR DESCRIPTION
## Summary of [issue](https://github.com/ita-social-projects/what-front/issues/328)

- add keys (fix warning);
- reduce whether a full-screen width or a custom scroll;
- fix options for secretary as if the user having this role could assign both mentor and student.

This PR closes #328 

## Summary of change

- proper keys for options were added;
- invalid class name was fixed;
- early displaying of "user not found" was fixed;
- select list includes "mentor" option if the current user role is secretary.

![image](https://user-images.githubusercontent.com/47292994/103291222-eb63d100-49f3-11eb-8b26-d67255852949.png)

