### PR TITLE
Yakymova #585 wrong name disabled secretaries

### DIFF
--- a/src/features/secretaries/list-of-secretaries/list-of-secretaries.js
+++ b/src/features/secretaries/list-of-secretaries/list-of-secretaries.js
@@ -386,7 +386,7 @@ export const ListOfSecretaries = () => {
                 )}
                 htmlFor="switchDisabled"
               >
-                Show disabled Secretaries
+                Disabled Secretaries
               </label>
             </div>
             <div className="col-2 d-flex">

--- a/src/features/students/list-of-students/list-of-students.js
+++ b/src/features/students/list-of-students/list-of-students.js
@@ -289,7 +289,7 @@ export const ListOfStudents = () => {
                 className={classNames('custom-control-label', styles['custom-control-label'])}
                 htmlFor="show-disabled-check"
               >
-                Show disabled students
+                Disabled students
               </label>
             </div>
             <div className="col-2 mx-2 d-flex">


### PR DESCRIPTION
The titles of disable switchers (Secretaries && Students lists) were stuck to one mode.

Bug assue: https://github.com/ita-social-projects/what-front/issues/585