### PR TITLE
Kryoka 426 error isnt displayed on the add lesson page

### DIFF
--- a/src/features/lessons/add-lesson/add-lesson.js
+++ b/src/features/lessons/add-lesson/add-lesson.js
@@ -15,6 +15,7 @@ import { Formik, Field, Form, FieldArray } from 'formik';
 
 import classNames from 'classnames';
 import styles from './add-lesson.scss';
+import { lessonValidation } from '@features/validation/validation-helpers';
 
 export const AddLesson = () => {
   const history = useHistory();
@@ -253,9 +254,9 @@ export const AddLesson = () => {
                   formData,
                 }}
                 onSubmit={onSubmit}
-                validationSchema={addLessonValidation}
+                validationSchema={lessonValidation}
               >
-                {({ errors }) => (
+                {({ errors, touched }) => (
                   <Form id="form" className={classNames(styles.size, 'd-flex flex-row')}>
                     <div className="col-12">
                       <div className="mt-3 form-group row">
@@ -263,27 +264,30 @@ export const AddLesson = () => {
                         <div className="col-sm-8">
                           <Field
                             type="text"
-                            className={classNames('form-control', { 'border-danger': errors.themeName })}
+                            className={classNames('form-control',
+                              { 'border-danger': !!(errors.themeName && touched.themeName) })}
                             name="themeName"
                             id="inputLessonTheme"
                             placeholder="Lesson Theme"
                             required
                           />
                           {
-                          errors.themeName
-                            ? <div className={styles.error}>{errors.themeName}</div>
-                            : null
+                          errors.themeName && touched.themeName &&
+                          <div className={styles.error}>{errors.themeName}</div>
                         }
                         </div>
                       </div>
                       <div className="form-group row">
                         <label htmlFor="inputGroupName" className="col-sm-4 col-form-label">Group Name:</label>
                         <div className="col-sm-8 input-group">
-                          <input
+                          <Field
                             name="groupName"
                             id="inputGroupName"
                             type="text"
-                            className={classNames('form-control group-input', { 'border-danger': groupError })}
+                            className={
+                              classNames('form-control group-input',
+                                { 'border-danger': !!(errors.groupName && touched.groupName) })
+                            }
                             placeholder="Group Name"
                             onChange={handleGroupChange}
                             onFocus={hideClassRegister}
@@ -298,10 +302,9 @@ export const AddLesson = () => {
                           </datalist>
                         </div>
                         {
-                            groupError
-                              ? <div className={classNames('col-8 offset-4', styles.error)}>Invalid group name</div>
-                              : null
-                          }
+                          errors.groupName && touched.groupName &&
+                          <div className={styles.error}>{errors.groupName}</div>
+                        }
                       </div>
                       <div className="form-group row">
                         <label className="col-sm-4 col-form-label" htmlFor="choose-date/time">Lesson Date/Time:</label>
@@ -319,8 +322,8 @@ export const AddLesson = () => {
                       <div className="form-group row">
                         <label className="col-sm-4 col-form-label" htmlFor="mentorEmail">Mentor Email:</label>
                         <div className="col-md-8 input-group">
-                          <input
-                            className={classNames('form-control group-input', { 'border-danger': mentorError })}
+                          <Field
+                            className={classNames('form-control group-input', { 'border-danger': !!(errors.mentorEmail && touched.mentorEmail) })}
                             type="text"
                             name="mentorEmail"
                             id="mentorEmail"
@@ -339,10 +342,9 @@ export const AddLesson = () => {
                           </datalist>
                         </div>
                         {
-                            mentorError
-                              ? <div className={classNames('col-8 offset-4', styles.error)}>Invalid mentor email</div>
-                              : null
-                          }
+                          errors.mentorEmail && touched.mentorEmail &&
+                          <div className={styles.error}>{errors.mentorEmail}</div>
+                        }
                       </div>
                     </div>
                     { classRegister && formData && (

--- a/src/features/lessons/add-lesson/add-lesson.js
+++ b/src/features/lessons/add-lesson/add-lesson.js
@@ -12,6 +12,7 @@ import { Button, WithLoading } from '@/components';
 import { addLessonValidation } from '@features/validation/validation-helpers.js';
 import { addAlert } from '@/features';
 import { Formik, Field, Form, FieldArray } from 'formik';
+import { Other } from '@/utils'
 
 import classNames from 'classnames';
 import styles from './add-lesson.scss';
@@ -93,10 +94,6 @@ export const AddLesson = () => {
     }
   }, [addError, addIsLoaded, dispatchAddAlert, history]);
 
-  const capitalizeTheme = (str) => str.toLowerCase()
-    .split(/\s+/)
-    .map((word) => word[0].toUpperCase() + word.substring(1)).join(' ');
-
   const openStudentDetails = useCallback((id) => {
     history.push(`${paths.STUDENTS_DETAILS}/${id}`);
   }, [history]);
@@ -123,7 +120,7 @@ export const AddLesson = () => {
 
     const mentorData = mentors.find((mentor) => mentor.email === mentorInput);
 
-    const theme = capitalizeTheme(themeName);
+    const theme = Other.capitalizeTheme(themeName);
 
     const lessonObject = {
       lessonDate,

--- a/src/features/lessons/add-lesson/add-lesson.js
+++ b/src/features/lessons/add-lesson/add-lesson.js
@@ -168,14 +168,14 @@ export const AddLesson = () => {
       setGroupError(false);
     }
 
-    !studentsGroup && setCorrectError('#inputGroupName', setGroupError);
-    !mentorInput && setCorrectError('#mentorEmail', setMentorError);
+    !studentsGroup && setCorrectError('#inputGroupName', setGroupError, 'group name');
+    !mentorInput && setCorrectError('#mentorEmail', setMentorError, 'mentor email');
   };
 
-  const setCorrectError = (inputSelector, setError) => {
+  const setCorrectError = (inputSelector, setError, fieldName) => {
     const value = document.querySelector(inputSelector).value;
 
-    value ? setError('Invalid group name') : setError('This field is required');
+    value ? setError(`Invalid ${fieldName}`) : setError('This field is required');
   };
 
   const hideClassRegister = () => {
@@ -189,7 +189,7 @@ export const AddLesson = () => {
     const mentorData = mentors.find((mentor) => mentor.email === ev.target.value);
 
     mentorData ? setMentorError(false)
-      : setCorrectError('#mentorEmail', setMentorError);
+      : setCorrectError('#mentorEmail', setMentorError, 'mentor email');
   };
 
   const handleGroupChange = (ev) => {
@@ -201,7 +201,7 @@ export const AddLesson = () => {
       setBtnSave(false);
       setClassRegister(false);
     } else {
-      setCorrectError('#inputGroupName', setGroupError);
+      setCorrectError('#inputGroupName', setGroupError, 'group name');
     }
   };
 

--- a/src/features/lessons/add-lesson/add-lesson.js
+++ b/src/features/lessons/add-lesson/add-lesson.js
@@ -12,7 +12,7 @@ import { Button, WithLoading } from '@/components';
 import { addLessonValidation } from '@features/validation/validation-helpers.js';
 import { addAlert } from '@/features';
 import { Formik, Field, Form, FieldArray } from 'formik';
-import { Other } from '@/utils';
+import { CommonHelpers } from '@/utils';
 
 import classNames from 'classnames';
 import styles from './add-lesson.scss';
@@ -120,7 +120,7 @@ export const AddLesson = () => {
 
     const mentorData = mentors.find((mentor) => mentor.email === mentorInput);
 
-    const theme = Other.capitalizeTheme(themeName);
+    const theme = CommonHelpers.capitalizeTheme(themeName);
 
     const lessonObject = {
       lessonDate,

--- a/src/features/lessons/add-lesson/add-lesson.js
+++ b/src/features/lessons/add-lesson/add-lesson.js
@@ -232,7 +232,7 @@ export const AddLesson = () => {
               Server Problems
             </div>
           )}
-          <div class='col-12'>
+          <div className='col-12'>
             <h3>Add a Lesson</h3>
             <hr />
             <WithLoading

--- a/src/features/lessons/add-lesson/add-lesson.js
+++ b/src/features/lessons/add-lesson/add-lesson.js
@@ -170,10 +170,15 @@ export const AddLesson = () => {
       setBtnSave(true);
       setClassRegister(true);
       setGroupError(false);
-    }
-    if (!studentsGroup) {
-      setGroupError(true);
-    }
+    } else simpleValidation('#inputGroupName', setGroupError);
+
+    !mentorInput && simpleValidation('#mentorEmail', setMentorError)
+  };
+
+  const simpleValidation = (inputSelector, setError) => {
+    const value = document.querySelector(inputSelector).value;
+
+    value ? setError('Invalid group name') : setError('This field is required');
   };
 
   const hideClassRegister = () => {
@@ -186,11 +191,8 @@ export const AddLesson = () => {
     setMentorInput(ev.target.value);
     const mentorData = mentors.find((mentor) => mentor.email === ev.target.value);
 
-    if (mentorData) {
-      setMentorError(false);
-    } else {
-      setMentorError(true);
-    }
+    if (mentorData) setMentorError(false);
+    else simpleValidation('#mentorEmail', setMentorError)
   };
 
   const handleGroupChange = (ev) => {
@@ -202,7 +204,7 @@ export const AddLesson = () => {
       setBtnSave(false);
       setClassRegister(false);
     } else {
-      setGroupError(true);
+      simpleValidation('#inputGroupName', setGroupError);
     }
   };
 
@@ -254,182 +256,200 @@ export const AddLesson = () => {
                   formData,
                 }}
                 onSubmit={onSubmit}
-                validationSchema={lessonValidation}
+                validationSchema={addLessonValidation}
               >
-                {({ errors, touched }) => (
-                  <Form id="form" className={classNames(styles.size, 'd-flex flex-row')}>
-                    <div className="col-12">
-                      <div className="mt-3 form-group row">
-                        <label htmlFor="inputLessonTheme" className="col-sm-4 col-form-label">Lesson Theme:</label>
-                        <div className="col-sm-8">
-                          <Field
-                            type="text"
-                            className={classNames('form-control',
-                              { 'border-danger': !!(errors.themeName && touched.themeName) })}
-                            name="themeName"
-                            id="inputLessonTheme"
-                            placeholder="Lesson Theme"
-                            required
-                          />
-                          {
-                          errors.themeName && touched.themeName &&
-                          <div className={styles.error}>{errors.themeName}</div>
-                        }
-                        </div>
-                      </div>
-                      <div className="form-group row">
-                        <label htmlFor="inputGroupName" className="col-sm-4 col-form-label">Group Name:</label>
-                        <div className="col-sm-8 input-group">
-                          <Field
-                            name="groupName"
-                            id="inputGroupName"
-                            type="text"
-                            className={
-                              classNames('form-control group-input',
-                                { 'border-danger': !!(errors.groupName && touched.groupName) })
-                            }
-                            placeholder="Group Name"
-                            onChange={handleGroupChange}
-                            onFocus={hideClassRegister}
-                            list="group-list"
-                            disabled={groupsIsLoading}
-                            required
-                          />
-                          <datalist id="group-list">
-                            {groups.map(({ id, name }) => (
-                              <option key={id}>{name}</option>
-                            ))}
-                          </datalist>
-                        </div>
-                        {
-                          errors.groupName && touched.groupName &&
-                          <div className={styles.error}>{errors.groupName}</div>
-                        }
-                      </div>
-                      <div className="form-group row">
-                        <label className="col-sm-4 col-form-label" htmlFor="choose-date/time">Lesson Date/Time:</label>
-                        <div className="col-md-8">
-                          <Field
-                            className="form-control"
-                            type="datetime-local"
-                            name="lessonDate"
-                            id="choose-date/time"
-                            max={today}
-                            required
-                          />
-                        </div>
-                      </div>
-                      <div className="form-group row">
-                        <label className="col-sm-4 col-form-label" htmlFor="mentorEmail">Mentor Email:</label>
-                        <div className="col-md-8 input-group">
-                          <Field
-                            className={classNames('form-control group-input', { 'border-danger': !!(errors.mentorEmail && touched.mentorEmail) })}
-                            type="text"
-                            name="mentorEmail"
-                            id="mentorEmail"
-                            list="mentor-list"
-                            placeholder="Mentor Email"
-                            onChange={handleMentorChange}
-                            disabled={mentorsIsLoading}
-                            required
-                          />
-                          <datalist id="mentor-list">
-                            {mentors.map(({ id, firstName, lastName, email }) => (
-                              <option key={id} value={email}>
-                                {`${firstName} ${lastName}`}
-                              </option>
-                            ))}
-                          </datalist>
-                        </div>
-                        {
-                          errors.mentorEmail && touched.mentorEmail &&
-                          <div className={styles.error}>{errors.mentorEmail}</div>
-                        }
-                      </div>
-                    </div>
-                    { classRegister && formData && (
-                    <div className="col-lg-12">
-                      <FieldArray name="formData">
-                        {() => (
-                          <div className={classNames(styles.list, 'col-lg-12 pt-2')}>
-                            <table className="table table-bordered table-hover">
-                              <thead>
-                                <tr>
-                                  <th scope="col" aria-label="first_col" />
-                                  <th scope="col">Full Student`s Name</th>
-                                  <th scope="col" className="text-center">Mark</th>
-                                  <th scope="col" className="text-center">Presence</th>
-                                </tr>
-                              </thead>
-                              <tbody>
-                                { formData && formData.length > 0 && (
-                                  formData.map((lessonVisit, index) => (
-                                    <tr key={lessonVisit.studentId}>
-                                      <th scope="row">{ index + 1 }</th>
-                                      <td>
-                                        <p
-                                          className={classNames(styles.link)}
-                                          onClick={() => openStudentDetails(lessonVisit.studentId)}
-                                        >
-                                          { lessonVisit.studentName }
-                                        </p>
-                                      </td>
-                                      <td>
-                                        <Field
-                                          name={`formData[${index}].studentMark`}
-                                          className={classNames(
-                                            'form-control',
-                                            { 'border-danger': markError },
-                                            styles.mode,
-                                          )}
-                                          type="number"
-                                          max="12"
-                                          min="0"
-                                          placeholder=""
-                                          onChange={handleMarkChange}
-                                          data-id={index}
-                                          disabled={!formData[index].presence}
-                                        />
-                                      </td>
-                                      <td>
-                                        <Field
-                                          name={`formData[${index}].presence`}
-                                          className={styles.mode}
-                                          type="checkbox"
-                                          onClick={handlePresenceChange}
-                                          data-id={index}
-                                          checked={formData[index].presence}
-                                        />
-                                      </td>
-                                    </tr>
-                                  ))
-                                )}
-                              </tbody>
-                            </table>
+                {({ errors, touched, setFieldTouched }) => (
+                  <Form id="form" className={classNames(styles.size)}>
+                    <div className='d-flex flex-row'>
+                      <div className="col-12">
+                        <div className="mt-3 form-group row">
+                          <label htmlFor="inputLessonTheme" className="col-sm-4 col-form-label">Lesson Theme:</label>
+                          <div className="col-sm-8">
+                            <Field
+                              type="text"
+                              className={classNames('form-control',
+                                { 'border-danger': !!(errors.themeName && touched.themeName) })}
+                              name="themeName"
+                              id="inputLessonTheme"
+                              placeholder="Lesson Theme"
+                              required
+                            />
+                            {
+                            errors.themeName &&
+                            <div className={styles.error}>{errors.themeName}</div>
+                          }
                           </div>
-                        )}
-                      </FieldArray>
+                        </div>
+                        <div className="form-group row">
+                          <label htmlFor="inputGroupName" className="col-sm-4 col-form-label">Group Name:</label>
+                          <div className="col-sm-8 input-group">
+                            <input
+                              name="groupName"
+                              id="inputGroupName"
+                              type="text"
+                              className={classNames('form-control group-input', { 'border-danger': !!groupError })}
+                              placeholder="Group Name"
+                              onChange={handleGroupChange}
+                              onFocus={hideClassRegister}
+                              list="group-list"
+                              disabled={groupsIsLoading}
+                              required
+                            />
+                            <datalist id="group-list">
+                              {groups.map(({ id, name }) => (
+                                <option key={id}>{name}</option>
+                              ))}
+                            </datalist>
+                          </div>
+                          {
+                            groupError
+                              ? <div className={classNames('col-8 offset-4', styles.error)}>{groupError}</div>
+                              : null
+                          }
+                        </div>
+                        <div className="form-group row">
+                          <label className="col-sm-4 col-form-label" htmlFor="choose-date/time">Lesson Date/Time:</label>
+                          <div className="col-md-8">
+                            <Field
+                              className="form-control"
+                              type="datetime-local"
+                              name="lessonDate"
+                              id="choose-date/time"
+                              max={today}
+                              required
+                            />
+                          </div>
+                        </div>
+                        <div className="form-group row">
+                          <label className="col-sm-4 col-form-label" htmlFor="mentorEmail">Mentor Email:</label>
+                          <div className="col-md-8 input-group">
+                            <input
+                              className={classNames('form-control group-input', { 'border-danger': !!mentorError })}
+                              type="text"
+                              name="mentorEmail"
+                              id="mentorEmail"
+                              list="mentor-list"
+                              placeholder="Mentor Email"
+                              onChange={handleMentorChange}
+                              disabled={mentorsIsLoading}
+                              required
+                            />
+                            <datalist id="mentor-list">
+                              {mentors.map(({ id, firstName, lastName, email }) => (
+                                <option key={id} value={email}>
+                                  {`${firstName} ${lastName}`}
+                                </option>
+                              ))}
+                            </datalist>
+                          </div>
+                          {
+                            mentorError
+                              ? <div className={classNames('col-8 offset-4', styles.error)}>{mentorError}</div>
+                              : null
+                          }
+                        </div>
+                      </div>
+                      { classRegister && formData && (
+                      <div className="col-lg-12">
+                        <FieldArray name="formData">
+                          {() => (
+                            <div className={classNames(styles.list, 'col-lg-12 pt-2')}>
+                              <table className="table table-bordered table-hover">
+                                <thead>
+                                  <tr>
+                                    <th scope="col" aria-label="first_col" />
+                                    <th scope="col">Full Student`s Name</th>
+                                    <th scope="col" className="text-center">Mark</th>
+                                    <th scope="col" className="text-center">Presence</th>
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  { formData && formData.length > 0 && (
+                                    formData.map((lessonVisit, index) => (
+                                      <tr key={lessonVisit.studentId}>
+                                        <th scope="row">{ index + 1 }</th>
+                                        <td>
+                                          <p
+                                            className={classNames(styles.link)}
+                                            onClick={() => openStudentDetails(lessonVisit.studentId)}
+                                          >
+                                            { lessonVisit.studentName }
+                                          </p>
+                                        </td>
+                                        <td>
+                                          <Field
+                                            name={`formData[${index}].studentMark`}
+                                            className={classNames(
+                                              'form-control',
+                                              { 'border-danger': markError },
+                                              styles.mode,
+                                            )}
+                                            type="number"
+                                            max="12"
+                                            min="0"
+                                            placeholder=""
+                                            onChange={handleMarkChange}
+                                            data-id={index}
+                                            disabled={!formData[index].presence}
+                                          />
+                                        </td>
+                                        <td>
+                                          <Field
+                                            name={`formData[${index}].presence`}
+                                            className={styles.mode}
+                                            type="checkbox"
+                                            onClick={handlePresenceChange}
+                                            data-id={index}
+                                            checked={formData[index].presence}
+                                          />
+                                        </td>
+                                      </tr>
+                                    ))
+                                  )}
+                                </tbody>
+                              </table>
+                            </div>
+                          )}
+                        </FieldArray>
+                      </div>
+                      )}
                     </div>
-                    )}
+                    <div className={classNames(styles.placement, 'col-12')}>
+                      <button form="form" type="button" className="btn btn-secondary btn-lg" onClick={handleCancel}>Cancel</button>
+                      {btnSave
+                        ? <button form="form" type="submit" className="btn btn-success btn-lg">Save</button>
+                        : (
+                          <Button
+                            className="btn btn-success btn-lg"
+                            onClick={(event) => {
+                              event.preventDefault();
+                              setFieldTouched();
+                              openClassRegister();
+                            }}
+                          >
+                            Class Register
+                          </Button>
+                        )}
+                    </div>
                   </Form>
                 )}
               </Formik>
             </WithLoading>
           </div>
         </div>
-        <div className={classNames(styles.placement, 'col-12')}>
-          <button form="form" type="button" className="btn btn-secondary btn-lg" onClick={handleCancel}>Cancel</button>
-          {btnSave
-            ? <button form="form" type="submit" className="btn btn-success btn-lg">Save</button>
-            : (
-              <Button
-                className="btn btn-success btn-lg"
-                onClick={openClassRegister}
-              >
-                Class Register
-              </Button>
-            )}
-        </div>
+        {/*<div className={classNames(styles.placement, 'col-12')}>*/}
+        {/*  <button form="form" type="button" className="btn btn-secondary btn-lg" onClick={handleCancel}>Cancel</button>*/}
+        {/*  {btnSave*/}
+        {/*    ? <button form="form" type="submit" className="btn btn-success btn-lg">Save</button>*/}
+        {/*    : (*/}
+        {/*      <Button*/}
+        {/*        className="btn btn-success btn-lg"*/}
+        {/*        onClick={openClassRegister}*/}
+        {/*      >*/}
+        {/*        Class Register*/}
+        {/*      </Button>*/}
+        {/*    )}*/}
+        {/*</div>*/}
       </div>
     </div>
   );

--- a/src/features/lessons/add-lesson/add-lesson.js
+++ b/src/features/lessons/add-lesson/add-lesson.js
@@ -12,7 +12,7 @@ import { Button, WithLoading } from '@/components';
 import { addLessonValidation } from '@features/validation/validation-helpers.js';
 import { addAlert } from '@/features';
 import { Formik, Field, Form, FieldArray } from 'formik';
-import { Other } from '@/utils'
+import { Other } from '@/utils';
 
 import classNames from 'classnames';
 import styles from './add-lesson.scss';
@@ -168,7 +168,7 @@ export const AddLesson = () => {
       setGroupError(false);
     } else simpleValidation('#inputGroupName', setGroupError);
 
-    !mentorInput && simpleValidation('#mentorEmail', setMentorError)
+    !mentorInput && simpleValidation('#mentorEmail', setMentorError);
   };
 
   const simpleValidation = (inputSelector, setError) => {
@@ -236,11 +236,11 @@ export const AddLesson = () => {
             <hr />
             <WithLoading
               isLoading={
-                  lessonsIsLoading
-                  || mentorsIsLoading
-                  || studentsIsLoading
-                  || groupsIsLoading
-                }
+                lessonsIsLoading
+                || mentorsIsLoading
+                || studentsIsLoading
+                || groupsIsLoading
+              }
               className={classNames(styles['loader-centered'])}
             >
               <Formik
@@ -271,9 +271,9 @@ export const AddLesson = () => {
                               required
                             />
                             {
-                            errors.themeName &&
-                            <div className={styles.error}>{errors.themeName}</div>
-                          }
+                              errors.themeName &&
+                              <div className={styles.error}>{errors.themeName}</div>
+                            }
                           </div>
                         </div>
                         <div className="form-group row">
@@ -345,22 +345,22 @@ export const AddLesson = () => {
                           }
                         </div>
                       </div>
-                      { classRegister && formData && (
-                      <div className={classRegister ? 'col-lg-6' : 'col-lg-12'}>
-                        <FieldArray name="formData">
-                          {() => (
-                            <div className={classNames(styles.list, 'col-lg-12 pt-2')}>
-                              <table className="table table-bordered table-hover">
-                                <thead>
+                      {classRegister && formData && (
+                        <div className={classRegister ? 'col-lg-6' : 'col-lg-12'}>
+                          <FieldArray name="formData">
+                            {() => (
+                              <div className={classNames(styles.list, 'col-lg-12 pt-2')}>
+                                <table className="table table-bordered table-hover">
+                                  <thead>
                                   <tr>
                                     <th scope="col" aria-label="first_col" />
                                     <th scope="col">Full Student`s Name</th>
                                     <th scope="col" className="text-center">Mark</th>
                                     <th scope="col" className="text-center">Presence</th>
                                   </tr>
-                                </thead>
-                                <tbody>
-                                  { formData && formData.length > 0 && (
+                                  </thead>
+                                  <tbody>
+                                  {formData && formData.length > 0 && (
                                     formData.map((lessonVisit, index) => (
                                       <tr key={lessonVisit.studentId}>
                                         <th scope="row">{ index + 1 }</th>
@@ -402,12 +402,12 @@ export const AddLesson = () => {
                                       </tr>
                                     ))
                                   )}
-                                </tbody>
-                              </table>
-                            </div>
-                          )}
-                        </FieldArray>
-                      </div>
+                                  </tbody>
+                                </table>
+                              </div>
+                            )}
+                          </FieldArray>
+                        </div>
                       )}
                     </div>
                     <div className='col-12 d-flex justify-content-between'>

--- a/src/features/lessons/add-lesson/add-lesson.js
+++ b/src/features/lessons/add-lesson/add-lesson.js
@@ -15,7 +15,6 @@ import { Formik, Field, Form, FieldArray } from 'formik';
 
 import classNames from 'classnames';
 import styles from './add-lesson.scss';
-import { lessonValidation } from '@features/validation/validation-helpers';
 
 export const AddLesson = () => {
   const history = useHistory();
@@ -235,7 +234,7 @@ export const AddLesson = () => {
               Server Problems
             </div>
           )}
-          <div className={`${classRegister ? 'col-6' : 'col-12'}`}>
+          <div class='col-12'>
             <h3>Add a Lesson</h3>
             <hr />
             <WithLoading
@@ -260,11 +259,11 @@ export const AddLesson = () => {
               >
                 {({ errors, touched, setFieldTouched }) => (
                   <Form id="form" className={classNames(styles.size)}>
-                    <div className='d-flex flex-row'>
-                      <div className="col-12">
+                    <div className='d-flex flex-sm-column flex-lg-row'>
+                      <div className={classRegister ? 'col-lg-6' : 'col-lg-12'}>
                         <div className="mt-3 form-group row">
-                          <label htmlFor="inputLessonTheme" className="col-sm-4 col-form-label">Lesson Theme:</label>
-                          <div className="col-sm-8">
+                          <label htmlFor="inputLessonTheme" className="col-md-4 col-form-label">Lesson Theme:</label>
+                          <div className="col-md-8">
                             <Field
                               type="text"
                               className={classNames('form-control',
@@ -281,8 +280,8 @@ export const AddLesson = () => {
                           </div>
                         </div>
                         <div className="form-group row">
-                          <label htmlFor="inputGroupName" className="col-sm-4 col-form-label">Group Name:</label>
-                          <div className="col-sm-8 input-group">
+                          <label htmlFor="inputGroupName" className="col-md-4 col-form-label">Group Name:</label>
+                          <div className="col-md-8 input-group">
                             <input
                               name="groupName"
                               id="inputGroupName"
@@ -308,7 +307,7 @@ export const AddLesson = () => {
                           }
                         </div>
                         <div className="form-group row">
-                          <label className="col-sm-4 col-form-label" htmlFor="choose-date/time">Lesson Date/Time:</label>
+                          <label className="col-md-4 col-form-label" htmlFor="choose-date/time">Lesson Date/Time:</label>
                           <div className="col-md-8">
                             <Field
                               className="form-control"
@@ -321,7 +320,7 @@ export const AddLesson = () => {
                           </div>
                         </div>
                         <div className="form-group row">
-                          <label className="col-sm-4 col-form-label" htmlFor="mentorEmail">Mentor Email:</label>
+                          <label className="col-md-4 col-form-label" htmlFor="mentorEmail">Mentor Email:</label>
                           <div className="col-md-8 input-group">
                             <input
                               className={classNames('form-control group-input', { 'border-danger': !!mentorError })}
@@ -350,7 +349,7 @@ export const AddLesson = () => {
                         </div>
                       </div>
                       { classRegister && formData && (
-                      <div className="col-lg-12">
+                      <div className={classRegister ? 'col-lg-6' : 'col-lg-12'}>
                         <FieldArray name="formData">
                           {() => (
                             <div className={classNames(styles.list, 'col-lg-12 pt-2')}>
@@ -414,7 +413,7 @@ export const AddLesson = () => {
                       </div>
                       )}
                     </div>
-                    <div className={classNames(styles.placement, 'col-12')}>
+                    <div className='col-12 d-flex justify-content-between'>
                       <button form="form" type="button" className="btn btn-secondary btn-lg" onClick={handleCancel}>Cancel</button>
                       {btnSave
                         ? <button form="form" type="submit" className="btn btn-success btn-lg">Save</button>
@@ -437,19 +436,6 @@ export const AddLesson = () => {
             </WithLoading>
           </div>
         </div>
-        {/*<div className={classNames(styles.placement, 'col-12')}>*/}
-        {/*  <button form="form" type="button" className="btn btn-secondary btn-lg" onClick={handleCancel}>Cancel</button>*/}
-        {/*  {btnSave*/}
-        {/*    ? <button form="form" type="submit" className="btn btn-success btn-lg">Save</button>*/}
-        {/*    : (*/}
-        {/*      <Button*/}
-        {/*        className="btn btn-success btn-lg"*/}
-        {/*        onClick={openClassRegister}*/}
-        {/*      >*/}
-        {/*        Class Register*/}
-        {/*      </Button>*/}
-        {/*    )}*/}
-        {/*</div>*/}
       </div>
     </div>
   );

--- a/src/features/lessons/add-lesson/add-lesson.js
+++ b/src/features/lessons/add-lesson/add-lesson.js
@@ -166,12 +166,13 @@ export const AddLesson = () => {
       setBtnSave(true);
       setClassRegister(true);
       setGroupError(false);
-    } else simpleValidation('#inputGroupName', setGroupError);
+    }
 
-    !mentorInput && simpleValidation('#mentorEmail', setMentorError);
+    !studentsGroup && setCorrectError('#inputGroupName', setGroupError);
+    !mentorInput && setCorrectError('#mentorEmail', setMentorError);
   };
 
-  const simpleValidation = (inputSelector, setError) => {
+  const setCorrectError = (inputSelector, setError) => {
     const value = document.querySelector(inputSelector).value;
 
     value ? setError('Invalid group name') : setError('This field is required');
@@ -187,8 +188,8 @@ export const AddLesson = () => {
     setMentorInput(ev.target.value);
     const mentorData = mentors.find((mentor) => mentor.email === ev.target.value);
 
-    if (mentorData) setMentorError(false);
-    else simpleValidation('#mentorEmail', setMentorError)
+    mentorData ? setMentorError(false)
+      : setCorrectError('#mentorEmail', setMentorError);
   };
 
   const handleGroupChange = (ev) => {
@@ -200,7 +201,7 @@ export const AddLesson = () => {
       setBtnSave(false);
       setClassRegister(false);
     } else {
-      simpleValidation('#inputGroupName', setGroupError);
+      setCorrectError('#inputGroupName', setGroupError);
     }
   };
 

--- a/src/features/validation/validation-helpers.js
+++ b/src/features/validation/validation-helpers.js
@@ -67,6 +67,7 @@ export const addLessonValidation = Yup.object().shape({
   themeName: Yup.string()
     .min(1, 'Too short')
     .max(200, 'Too long')
+    .matches('^[a-zA-Zа-яА-ЯЇїІіЄєҐґ0-9][a-zA-Zа-яА-ЯЇїІіЄєҐґ 0-9]*$', 'Invalid lesson theme')
     .required('This field is required'),
   lessonDate: Yup.string()
     .max(new Date(), 'The lesson cannot start in the future')

--- a/src/utils/helpers/common-helpers.js
+++ b/src/utils/helpers/common-helpers.js
@@ -1,0 +1,5 @@
+export class CommonHelpers {
+  static capitalizeTheme = (str) => str.toLowerCase()
+    .split(/\s+/)
+    .map((word) => word[0].toUpperCase() + word.substring(1)).join(' ');
+}

--- a/src/utils/helpers/cookie.js
+++ b/src/utils/helpers/cookie.js
@@ -16,9 +16,3 @@ export class Cookie{
       document.cookie = `${cname}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
   }
 }
-
-export class CommonHelpers {
-  static capitalizeTheme = (str) => str.toLowerCase()
-    .split(/\s+/)
-    .map((word) => word[0].toUpperCase() + word.substring(1)).join(' ');
-}

--- a/src/utils/helpers/helpers.js
+++ b/src/utils/helpers/helpers.js
@@ -17,7 +17,7 @@ export class Cookie{
   }
 }
 
-export class Other {
+export class CommonHelpers {
   static capitalizeTheme = (str) => str.toLowerCase()
     .split(/\s+/)
     .map((word) => word[0].toUpperCase() + word.substring(1)).join(' ');

--- a/src/utils/helpers/helpers.js
+++ b/src/utils/helpers/helpers.js
@@ -16,3 +16,9 @@ export class Cookie{
       document.cookie = `${cname}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
   }
 }
+
+export class Other {
+  static capitalizeTheme = (str) => str.toLowerCase()
+    .split(/\s+/)
+    .map((word) => word[0].toUpperCase() + word.substring(1)).join(' ');
+}

--- a/src/utils/helpers/index.js
+++ b/src/utils/helpers/index.js
@@ -1,1 +1,1 @@
-export { Cookie, Other } from './helpers.js';
+export { Cookie, CommonHelpers } from './helpers.js';

--- a/src/utils/helpers/index.js
+++ b/src/utils/helpers/index.js
@@ -1,1 +1,1 @@
-export { Cookie } from './helpers.js';
+export { Cookie, Other } from './helpers.js';

--- a/src/utils/helpers/index.js
+++ b/src/utils/helpers/index.js
@@ -1,2 +1,3 @@
-export { Cookie, CommonHelpers } from './helpers.js';
+export { Cookie } from './cookie.js';
 export { formatDate } from './date.js';
+export { CommonHelpers } from './common-helpers.js';

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,1 +1,1 @@
-export { Cookie } from './helpers/index.js';
+export { Cookie, Other } from './helpers/index.js';

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,1 +1,1 @@
-export { Cookie, Other } from './helpers/index.js';
+export { Cookie, CommonHelpers } from './helpers/index.js';


### PR DESCRIPTION
## Code reviewers

- [x] @so2niko 
- [x] @CaelumVallis 
- [x] @AllaYakymova 

## Task
https://github.com/ita-social-projects/what-front/issues/426

## Summary of change

1. Added helper class 'CommonHelpers' for dubplicated code in AddLessons.
2. Added function for setting correct error (then we can display error message, instead of true/false values).
3. Changed code style in several places -> es6.
4. Added usage of 'touched' and setFieldTouched (Formik) for displaying errors after click 'Class Register'.
5. Changed markup - moved buttons into form.
6. Added validation for themeName (Lesson Theme) in Yup schema.
7. Changed SRS for field "Lesson Theme" in "Add lesson" page.
8. Divided helpers to cookie and common-helpers.
