### PR TITLE
extra condition added when date filter inputs are empty

### DIFF
--- a/src/features/lessons/list-of-lessons/list-of-lessons.js
+++ b/src/features/lessons/list-of-lessons/list-of-lessons.js
@@ -98,6 +98,13 @@ export const ListOfLessons = () => {
       });
       return;
     }
+
+    if (!filterStartDate && !filterEndDate) {
+      setFilteredLessonsList(rawLessonsList);
+      setCurrentPage(1);
+      return;
+    }
+
     setStartDateFilterBorder(false);
 
     const lessons = rawLessonsList.filter((lesson) => {


### PR DESCRIPTION
Close #605

## Summary of issue

If you delete dates in date inputs, then lessons are not displayed.
The expected result is a list of all metor lessons.

## Summary of change

Added an additional condition for checking empty date inputs.

video:

https://user-images.githubusercontent.com/48652896/122018540-a1b54a00-cdcb-11eb-8b03-9658f4f1c3f1.mov


